### PR TITLE
Support the "prevent_initial_call" option for "du.callback".

### DIFF
--- a/dash_uploader/callbacks.py
+++ b/dash_uploader/callbacks.py
@@ -49,7 +49,6 @@ def create_dash_callback(callback, settings):  # pylint: disable=redefined-outer
 def callback(
     output,
     id="dash-uploader",
-    prevent_initial_call=False,
 ):
     """
     Add a callback to dash application.
@@ -62,18 +61,6 @@ def callback(
         The output dash component
     id: str
         The id of the du.Upload component.
-    prevent_initial_call: bool
-        The optional argument `prevent_initial_call`
-        is supported since dash v1.12.0. When set
-        True, it will cause the callback not to fire
-        when its outputs are first added to the page.
-        Defaults to `False` unless
-        `prevent_initial_callbacks = True` at the
-        app level.
-        Compatibility:
-        Only works for dash>=1.12.0. If the current
-        dash is a pre-release version or an earlier
-        version, this option would be ignored.
 
     Example
     -------
@@ -114,7 +101,7 @@ def callback(
 
         kwargs = dict()
         if compare_dash_version("1.12"):
-            kwargs["prevent_initial_call"] = prevent_initial_call
+            kwargs["prevent_initial_call"] = True
         dash_callback = settings.app.callback(
             output,
             [Input(id, "isCompleted")],

--- a/dash_uploader/upload.py
+++ b/dash_uploader/upload.py
@@ -130,6 +130,7 @@ def Upload(
 
     arguments = dict(
         id=id,
+        isCompleted=False,
         # Have not tested if using many files
         # is reliable -> Do not allow
         maxFiles=max_files,


### PR DESCRIPTION
Support the `prevent_initial_call` option when `dash>=1.12.0`.

The option `prevent_initial_call` is designed for improving the efficiency of the callbacks since `dash==1.12.0`. If this option is enabled, the callback would not be fired during the initialization. An official example could be referred [here](https://dash.plotly.com/advanced-callbacks#prevent-callback-execution-upon-initial-component-render).

-----
To author:
1. Currently, I have only modified the codes. If you think this pull request is acceptable, please let me know. I could also update the documentation before you merge it. Thank you!
2. In this project, the callback should be always fired after the file uploaded, so I think that the initial fire is not required. Although `prevent_initial_call` is set `False` by default in `dash`, it is better to make `prevent_initial_call=True` in our case. If you agree with this suggestion, I could update the default value.