### PR TITLE
Support multiple Dash or Flask apps for du.configure_upload.

### DIFF
--- a/dash_uploader/configure_upload.py
+++ b/dash_uploader/configure_upload.py
@@ -1,15 +1,86 @@
 import logging
 
+import dash
+import flask
+
 import dash_uploader.settings as settings
-from dash_uploader.upload import update_upload_api
 from dash_uploader.httprequesthandler import HttpRequestHandler
 
 
 logger = logging.getLogger("dash_uploader")
 
 
+def update_upload_api(requests_pathname_prefix, upload_api):
+    """Path join for the API path name.
+    This is a private method, and should not be exposed to users.
+    """
+    if requests_pathname_prefix == "/":
+        return upload_api
+    return "/".join(
+        [
+            requests_pathname_prefix.rstrip("/"),
+            upload_api.lstrip("/"),
+        ]
+    )
+
+
+def check_app(app):
+    """Check the validity of the provided app.
+    The app requires to be a dash.Dash instance or a flask.Flask
+    instance. It should not be repeated in the user configurations.
+    This is a private method, and should not be exposed to users.
+    """
+    is_dash = isinstance(app, dash.Dash)
+    if not is_dash and not isinstance(app, flask.Flask):
+        raise TypeError(
+            'The argument "app" requires to be a dash.Dash instance or a flask.Flask instance.'
+        )
+    return is_dash
+
+
+def check_upload_component_ids(upload_component_ids):
+    """Check the validity of the component ids.
+    This function is used for checking the validity of provided component
+    ids. A valid id should be a non-empty str and not repeated in the
+    configurations.
+    This is a private method, and should not be exposed to users.
+    """
+    # When None, check the default configs.
+    if upload_component_ids is None:
+        if settings.user_configs_default is not None:
+            raise ValueError(
+                "The default app has been configured before. A repeated configuration is not allowed."
+            )
+        return None
+    # When not None, check the ids first.
+    valid_ids = None
+    if isinstance(upload_component_ids, str) and upload_component_ids != "":
+        valid_ids = (upload_component_ids,)
+    if isinstance(upload_component_ids, (list, tuple)):
+        if all(
+            map(lambda uid: isinstance(uid, str) and uid != "", upload_component_ids)
+        ):
+            valid_ids = tuple(upload_component_ids)
+    if valid_ids is None:
+        raise TypeError(
+            'The argument "upload_component_ids" should be None, str or [str].'
+        )
+    # Then, check the repetition of the provided ids.
+    for uid in valid_ids:
+        if uid in settings.user_configs_query:
+            raise ValueError(
+                'The component id "{0}" has been configured before. A repeated configuration is not allowed.'
+            )
+    return valid_ids
+
+
 def configure_upload(
-    app, folder, use_upload_id=True, upload_api=None, http_request_handler=None
+    app,
+    folder,
+    use_upload_id=True,
+    upload_api=None,
+    http_request_handler=None,
+    upload_component_ids=None,
 ):
     r"""
     Configure the upload APIs for dash app.
@@ -17,8 +88,9 @@ def configure_upload(
 
     Parameters
     ---------
-    app: dash.Dash
-        The application instance
+    app: dash.Dash or flask.Flask
+        The application instance. It is required to be a dash.Dash
+        for using du.callback.
     folder: str
         The folder where to upload files.
         Can be relative ("uploads") or
@@ -44,34 +116,59 @@ def configure_upload(
         If you provide a class, use a subclass of HttpRequestHandler.
         See the documentation of dash_uploader.HttpRequestHandler for
         more details.
+    upload_component_ids: None or str or [str]
+        A list of du.Upload component ids. If set None, this configuration would be
+        regarded as default configurations. If not, the registered app would be
+        configured for the provided components.
     """
-    settings.UPLOAD_FOLDER_ROOT = folder
-    settings.app = app
+    # Check the validity of arguments.
+    is_dash = check_app(app)
+    upload_component_ids = check_upload_component_ids(upload_component_ids)
 
+    # Configure the API. Extra configs are needed if using a proxy for dash app.
     if upload_api is None:
         upload_api = settings.upload_api
+    if is_dash and upload_api is not None:
+        routes_pathname_prefix = app.config.get("routes_pathname_prefix", "/")
+        requests_pathname_prefix = app.config.get("requests_pathname_prefix", "/")
+        service = update_upload_api(requests_pathname_prefix, upload_api)
+        full_upload_api = update_upload_api(routes_pathname_prefix, upload_api)
     else:
-        # Set the upload api since du.Upload components
-        # that are created after du.configure_upload
-        # need to be able to read the api endpoint.
-        settings.upload_api = upload_api
+        service = upload_api
+        full_upload_api = upload_api
 
-    # Needed if using a proxy
-    settings.requests_pathname_prefix = app.config.get("requests_pathname_prefix", "/")
-    settings.routes_pathname_prefix = app.config.get("routes_pathname_prefix", "/")
-
-    upload_api = update_upload_api(settings.routes_pathname_prefix, upload_api)
-
+    # Set the request handler.
     if http_request_handler is None:
         http_request_handler = HttpRequestHandler
 
+    server = app.server if is_dash else app
     decorate_server(
-        app.server,
+        server,
         folder,
-        upload_api,
+        full_upload_api,
         http_request_handler=http_request_handler,
         use_upload_id=use_upload_id,
     )
+
+    # If no bugs are triggered, would update the user configs.
+    # Set the upload api since du.Upload components
+    # that are created after du.configure_upload
+    # need to be able to read the api endpoint.
+    app_idx = len(settings.user_configs)
+    settings.user_configs.append({
+        "app": app,
+        "service": service,
+        "upload_api": upload_api,
+        "upload_folder_root": folder,
+        "is_dash": is_dash,
+        "upload_component_ids": upload_component_ids,
+    })
+    # Set the query.
+    if upload_component_ids is not None:
+        for uid in upload_component_ids:
+            settings.user_configs_query[uid] = app_idx
+    else:
+        settings.user_configs_default = app_idx
 
 
 def decorate_server(
@@ -106,5 +203,6 @@ def decorate_server(
         server, upload_folder=temp_base, use_upload_id=use_upload_id
     )
 
-    server.add_url_rule(upload_api, None, handler.get, methods=["GET"])
-    server.add_url_rule(upload_api, None, handler.post, methods=["POST"])
+    end_point = upload_api.lstrip("/").replace("/", ".")
+    server.add_url_rule(upload_api, end_point + ".get", handler.get, methods=["GET"])
+    server.add_url_rule(upload_api, end_point + ".post", handler.post, methods=["POST"])

--- a/dash_uploader/settings.py
+++ b/dash_uploader/settings.py
@@ -6,7 +6,7 @@ upload_api = "/API/resumable"
 # with a `requests_pathname_prefix`.
 # The front-end will prefix this string to the requests
 # that are made to the proxy server
-requests_pathname_prefix = '/'
+requests_pathname_prefix = "/"
 
 # From dash source code:
 # Note that `requests_pathname_prefix` is the prefix for the AJAX calls that
@@ -17,7 +17,7 @@ requests_pathname_prefix = '/'
 # If you need these to be different values then you should set
 # `requests_pathname_prefix` and `routes_pathname_prefix`,
 # not `url_base_pathname`.
-routes_pathname_prefix = '/'
+routes_pathname_prefix = "/"
 
 # User configurations:
 # The configuration dict is used for storing user-defined configurations.

--- a/dash_uploader/settings.py
+++ b/dash_uploader/settings.py
@@ -18,3 +18,33 @@ requests_pathname_prefix = '/'
 # `requests_pathname_prefix` and `routes_pathname_prefix`,
 # not `url_base_pathname`.
 routes_pathname_prefix = '/'
+
+# User configurations:
+# The configuration dict is used for storing user-defined configurations.
+# Each item is set by an independent du.configure_upload. The dict is
+# formatted as
+# user_configs = {
+#     'name1': {
+#         'app': dash.Dash() or flask.Flask(),
+#         'service': str,
+#         'upload_folder_root': str,
+#         'is_dash': bool
+#         'upload_component_ids': [str]
+#     },
+#     'name2': ...
+# }
+# It is not recommended to change this dict manually. It should be
+# automatically set by du.configure_upload.
+user_configs = {}
+
+# Backward query dict:
+# This dictionary is used for fast querying the items in user_configs. It
+# is formatted as
+# user_configs_query = {
+#     'upload_id_1': 'name1',
+#     'upload_id_2': 'name2',
+#     ...
+# }
+# It is not recommended to change this dict manually. It should be
+# automatically set by du.configure_upload.
+user_configs_query = {}

--- a/dash_uploader/settings.py
+++ b/dash_uploader/settings.py
@@ -2,49 +2,37 @@
 # The du.configure_upload can change this
 upload_api = "/API/resumable"
 
-# Needed if using a proxy; when dash.Dash is used
-# with a `requests_pathname_prefix`.
-# The front-end will prefix this string to the requests
-# that are made to the proxy server
-requests_pathname_prefix = "/"
-
-# From dash source code:
-# Note that `requests_pathname_prefix` is the prefix for the AJAX calls that
-# originate from the client (the web browser) and `routes_pathname_prefix` is
-# the prefix for the API routes on the backend (this flask server).
-# `url_base_pathname` will set `requests_pathname_prefix` and
-# `routes_pathname_prefix` to the same value.
-# If you need these to be different values then you should set
-# `requests_pathname_prefix` and `routes_pathname_prefix`,
-# not `url_base_pathname`.
-routes_pathname_prefix = "/"
-
 # User configurations:
-# The configuration dict is used for storing user-defined configurations.
-# Each item is set by an independent du.configure_upload. The dict is
+# The configuration list is used for storing user-defined configurations.
+# Each item is set by an independent du.configure_upload. The list is
 # formatted as
 # user_configs = {
-#     'name1': {
+#     {
 #         'app': dash.Dash() or flask.Flask(),
 #         'service': str,
+#         'upload_api': str,
+#         'routes_pathname_prefix': str,
+#         'requests_pathname_prefix': str,
 #         'upload_folder_root': str,
 #         'is_dash': bool
 #         'upload_component_ids': [str]
 #     },
-#     'name2': ...
+#     ...
 # }
 # It is not recommended to change this dict manually. It should be
 # automatically set by du.configure_upload.
-user_configs = {}
+user_configs = list()
 
 # Backward query dict:
 # This dictionary is used for fast querying the items in user_configs. It
 # is formatted as
 # user_configs_query = {
-#     'upload_id_1': 'name1',
-#     'upload_id_2': 'name2',
+#     'upload_id_1': list_index_1,
+#     'upload_id_2': list_index_2,
 #     ...
 # }
+# user_configs_query is a str (The default name of the configs.)
 # It is not recommended to change this dict manually. It should be
 # automatically set by du.configure_upload.
 user_configs_query = {}
+user_configs_default = None

--- a/dash_uploader/upload.py
+++ b/dash_uploader/upload.py
@@ -16,16 +16,15 @@ DEFAULT_STYLE = {
 }
 
 
-def update_upload_api(requests_pathname_prefix, upload_api):
-    '''Path join for the API path name.
+def query_service_addr(component_id):
+    """Query the service address by the given component id.
     This is a private method, and should not be exposed to users.
-    '''
-    if requests_pathname_prefix == '/':
-        return upload_api
-    return '/'.join([
-        requests_pathname_prefix.rstrip('/'),
-        upload_api.lstrip('/'),
-    ])
+    """
+    app_idx = settings.user_configs_query.get(component_id, None)
+    if app_idx is None:
+        app_idx = settings.user_configs_default
+    service_addr = settings.user_configs[app_idx]["service"]
+    return service_addr
 
 
 def combine(overiding_dict, base_dict):
@@ -125,8 +124,7 @@ def Upload(
     if upload_id is None:
         upload_id = uuid.uuid1()
 
-    service = update_upload_api(settings.requests_pathname_prefix,
-                                settings.upload_api)
+    service = query_service_addr(id)
 
     arguments = dict(
         id=id,


### PR DESCRIPTION
## Introduction
This PR preserves all existed APIs. In other words, the modifications are compatible with previous APIs.

This PR is designed for providing the following new API:
```python
du.configure_upload(app, UPLOAD_FOLDER_ROOT, upload_api='my-awesome-API/upload')
du.configure_upload(app, UPLOAD_FOLDER_ROOT, upload_api='my-awesome-API/upload-second', upload_component_ids='second')
```
where we have:
1. `du.configure_upload` could be used several times.
2. The argument `app` could be a `dash.Dash` instance or a `flask.Flask` instance. The argument type would be checked during the configuration.
3. A new argument `upload_component_ids` is provided, it could be
    * `None`: This is the default value. It means that this configuration is designed for default configurations.
    * `str`: This is the same as `(str, )`
    * `tuple` or `list`: A sequence of `str`. Each `str` is a component id. The component with the provided id would be configured by the provided configurations.
4. A simple check has been implemented for `upload_component_ids`. If it is not `None`, each item requires to be a non-empty `str`.

## Example

### For dash

```python
import dash
import dash_html_components as html
from dash.dependencies import Output
import dash_uploader as du

app = dash.Dash(
    __name__,
    assets_folder='./assets',
    assets_url_path='/assets',
    assets_ignore=r'.*.js'
)
app.title = 'A testing app.'
du.configure_upload(app, folder='upload', use_upload_id=False)
du.configure_upload(app, folder='upload', use_upload_id=False, upload_api='/api-uploader', upload_component_ids='uploader')

app.layout = html.Div(
    children=[
        du.Upload(
            id='uploader',
            text='Drag & Drop or Select a File',
            filetypes=['csv', 'zip'],
            upload_id='.',
            max_files=1,
            default_style={
                'width': '100%',
                'paddingLeft': '.5rem',
                'paddingRight': '.5rem',
                'minHeight': 'min-content',
                'lineHeight': '50px',
                'borderWidth': '1px',
                'borderStyle': 'dashed',
                'borderRadius': '5px',
                'textAlign': 'center'
            }
        ),
        html.Div(id='trigger-upload')
    ]
)


@du.callback(
    output=Output('trigger-upload', 'children'),
    id='uploader',
)
def trigger_upload(filenames):
    return html.Ul([html.Li(filenames)])


@app.server.after_request
def add_header(response):  # pylint: disable=unused-variable
    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
    response.headers["Pragma"] = "no-cache"
    response.headers["Expires"] = "0"
    response.headers['Cache-Control'] = 'public, max-age=0'
    response.cache_control.no_cache = True
    return response


if __name__ == '__main__':
    import colorama

    colorama.init()
    app.run_server(host='localhost', port=8060, debug=False)
```
Users could change the `upload_component_ids` in the second `du.configure_upload` and check what happens.

### For Flask

```python
import os
import flask

import dash_uploader as du

app = flask.Flask('test-uploader')

os.makedirs('upload', exist_ok=True)
du.configure_upload(app, folder='upload', upload_api='/dash-uploader', use_upload_id=False)
du.configure_upload(app, folder='upload', use_upload_id=False, upload_api='/uploader2', upload_component_ids='uploader2')

if __name__ == '__main__':
    import colorama

    colorama.init()
    app.run(host='localhost', port=8061, debug=False)
```
In this case, actually, we do not need to configure `upload_component_ids`, because a Flask app does not have components. It should be only used for managing APIs.

## For the next step

1. This PR is required for implementing the next feature (cross-domain) supports. I would not create the next PR before this PR is merged or closed.
2. If this PR is acceptable, I could start working on the documentation before merging it to the master branch.
3. We need to consider the following two topics:
    1. Currently, I add a check for the `du.callback`. If the component is not configured for a dash app (not configured or configured for a flask app), the `du.callback` would be forbidden. However, it is possible to implement a "Flask callback". We could invoke the callback by using the request handler after the final chunk uploaded. I am wondering whether we need to implement this feature (maybe this feature should be split into another PR).
    2. If we decide to implement the "Flask callback", there is an important problem. Because Flask app does not maintain the `component ids`, we may have two options for the implementation: (1) Add the component id in the arguments of the request. Then the `upload_component_ids` should be preserved because the Flask app could identify the component id. (2) Each "Flask callback" is designed for an API. In this case, we only need to add a check for `du.configure_upload` and forbid users to set `upload_component_ids` when `app` is a Flask app.

## Update report
1. Change the format of du.settings.
2. Move update_upload_api from du.upload to du.configure_upload.
3. Add an option "upload_component_ids" to du.configure_upload. This enables users to set different configurations for different components.
4. Support for flask app for du.configure_upload.