### PR TITLE
Change "Mb" to "MB"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python -m pip install dash-uploader --pre
 |                       | dash-uploader                                      | [dcc.Upload](https://dash.plotly.com/dash-core-components/upload)                                                                                                                    |
 | --------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Underlying technology | [flow.js](https://github.com/flowjs/flow.js/)      | HTML5 API                                                                                                                                                                            |
-| File size             | Unlimited                                          | max ~150-200Mb ([link](https://community.plotly.com/t/dash-upload-component-decoding-large-files/8033/11))                                                                           |
+| File size             | Unlimited                                          | max ~150-200MB ([link](https://community.plotly.com/t/dash-upload-component-decoding-large-files/8033/11))                                                                           |
 | Uploads to            | Hard disk (server side)                            | First to browser memory (user side) Then, to server using callbacks.                                                                                                                 |
 | Data type             | Uploaded as file; no need to parse at server side. | Uploaded as byte64 encoded string  -> Needs parsing                                                                                                                                  |
 | See upload progress?  | Progressbar out of the box                         | No upload indicators out of the box. Generic loading indicator possible. [Progressbar not possible](https://community.plotly.com/t/upload-after-confirmation-and-progress-bar/7172). |
@@ -110,7 +110,7 @@ du.configure_upload(app, UPLOAD_FOLDER_ROOT)
 def get_upload_component(id):
     return du.Upload(
         id=id,
-        max_file_size=1800,  # 1800 Mb
+        max_file_size=1800,  # 1800 MB
         filetypes=['csv', 'zip'],
         upload_id=uuid.uuid1(),  # Unique session id
     )

--- a/docs/dash-uploader.md
+++ b/docs/dash-uploader.md
@@ -159,7 +159,7 @@ The maximum file size in Megabytes. Default: 1024 (=1Gb).
 #### chunk_size: numeric
 *New in version **[0.6.0]***
 
-The chunk size in Megabytes. Optional. Default: 1 (=1Mb).
+The chunk size in Megabytes. Optional. Default: 1 (=1MB).
 
 #### default_style: None or dict
 Inline CSS styling for the main div element. 

--- a/src/lib/components/Upload_ReactComponent.react.js
+++ b/src/lib/components/Upload_ReactComponent.react.js
@@ -22,7 +22,7 @@ import './uploader.css';
  * @return {number} size_mb - Bytes converted to megabytes
  */
 function bytest_to_mb(size_bytes) {
-    // Mb = 1024*1024 bytes
+    // MB = 1024*1024 bytes
     return size_bytes / 1048576;
 }
 
@@ -171,7 +171,7 @@ export default class Upload_ReactComponent extends Component {
                 sumOfSizes += file.size
             }, this);
             if (sumOfSizes > this.props.maxTotalSize) {
-                alert('Total file size too large (' + bytest_to_mb(sumOfSizes).toFixed(1) + ' Mb) ! Maximum total filesize is: ' + bytest_to_mb(this.props.maxTotalSize).toFixed(1) + ' Mb')
+                alert('Total file size too large (' + bytest_to_mb(sumOfSizes).toFixed(1) + ' MB) ! Maximum total filesize is: ' + bytest_to_mb(this.props.maxTotalSize).toFixed(1) + ' MB')
                 return false
             }
         }
@@ -181,7 +181,7 @@ export default class Upload_ReactComponent extends Component {
     onProgress = () => {
 
         let parenthesisTxt = (bytest_to_mb(this.flow.sizeUploaded())).toFixed(2)
-            + ' Mb'
+            + ' MB'
         let filenameTxt = ''
 
         if (this.props.totalFilesCount > 1) {
@@ -327,9 +327,9 @@ export default class Upload_ReactComponent extends Component {
         }, this);
 
         if (n_too_large_files == 1) {
-            alert('1 file could not be uploaded, as the file is too large! Maximum allowed file size is ' + bytest_to_mb(this.props.maxFileSize).toFixed(1) + 'Mb')
+            alert('1 file could not be uploaded, as the file is too large! Maximum allowed file size is ' + bytest_to_mb(this.props.maxFileSize).toFixed(1) + 'MB')
         } else if (n_too_large_files > 1) {
-            alert(n_too_large_files.toString() + ' files could not be uploaded, as the file is too large! Maximum allowed file size is ' + bytest_to_mb(this.props.maxFileSize).toFixed(1) + 'Mb')
+            alert(n_too_large_files.toString() + ' files could not be uploaded, as the file is too large! Maximum allowed file size is ' + bytest_to_mb(this.props.maxFileSize).toFixed(1) + 'MB')
         }
     }
 
@@ -682,13 +682,13 @@ Upload_ReactComponent.propTypes = {
     totalFilesCount: PropTypes.number,
 
     /**
-     *  Size of uploaded files (Mb). Mb = 1024*1024 bytes.
+     *  Size of uploaded files (MB). MB = 1024*1024 bytes.
      */
     uploadedFilesSize: PropTypes.number,
 
     /**
-     *   Total size of uploaded files to be uploaded (Mb). 
-     *   Mb = 1024*1024 bytes.
+     *   Total size of uploaded files to be uploaded (MB). 
+     *   MB = 1024*1024 bytes.
      */
     totalFilesSize: PropTypes.number,
 }

--- a/tests/apps/disabled.py
+++ b/tests/apps/disabled.py
@@ -28,7 +28,7 @@ def get_upload_component(id):
         text="Drag and Drop files here",
         text_completed="Completed: ",
         cancel_button=True,
-        max_file_size=1800,  # 1800 Mb
+        max_file_size=1800,  # 1800 MB
         filetypes=["csv", "zip"],
         upload_id=uuid.uuid1(),  # Unique session id
         max_files=2,

--- a/tests/apps/testapp.py
+++ b/tests/apps/testapp.py
@@ -23,7 +23,7 @@ def get_upload_component(id):
         text_completed="Completed: ",
         cancel_button=True,
         pause_button=True,
-        # max_file_size=130,  # 130 Mb
+        # max_file_size=130,  # 130 MB
         # max_total_size=350,
         # filetypes=["csv", "zip"],
         upload_id=uuid.uuid1(),  # Unique session id

--- a/tests/apps/testapp_noretry_remove_file.py
+++ b/tests/apps/testapp_noretry_remove_file.py
@@ -36,7 +36,7 @@ def get_upload_component(id):
         text_completed="Completed: ",
         cancel_button=True,
         pause_button=True,
-        # max_file_size=130,  # 130 Mb
+        # max_file_size=130,  # 130 MB
         # max_total_size=350,
         # filetypes=["csv", "zip"],
         upload_id=uuid.uuid1(),  # Unique session id

--- a/tests/test_disabled.py
+++ b/tests/test_disabled.py
@@ -28,7 +28,7 @@ from .utils import create_file, load_text_file, expect_alert
 
 
 @pytest.fixture
-def testfile10Mb_csv():
+def testfile10MB_csv():
     file = Path(__file__).resolve().parent / "mytestfile.csv"
     create_file(file, filesize_mb=10)
     yield file
@@ -130,7 +130,7 @@ def test_disabled01_check_disabled_property_update(dash_duo):
 
 
 def test_disabled02_check_disabled_effect(
-    dash_duo, testfile10Mb_csv, testfileWrongType, js_drag_and_drop
+    dash_duo, testfile10MB_csv, testfileWrongType, js_drag_and_drop
 ):
     """Check the effectiveness of the disabled and disableDragAndDrop property.
     The upload component with "disabled" triggered would not accept any files.
@@ -176,7 +176,7 @@ def test_disabled02_check_disabled_effect(
             drag_and_drag_input = driver.execute_script(
                 js_drag_and_drop, upload, 20, 20
             )
-            drag_and_drag_input.send_keys(str(testfile10Mb_csv))
+            drag_and_drag_input.send_keys(str(testfile10MB_csv))
         else:
             # Ensure the uploading button is clickable.
             if expect_success:
@@ -192,7 +192,7 @@ def test_disabled02_check_disabled_effect(
                 return
 
             # Wait until file is uploaded
-            upload_input.send_keys(str(testfile10Mb_csv))
+            upload_input.send_keys(str(testfile10MB_csv))
 
         # The fail case would be used for checking the drag and drop mode.
         if expect_success:
@@ -218,9 +218,9 @@ def test_disabled02_check_disabled_effect(
         uploaded_file = callback_output.find_element(By.XPATH, "//ul").text
         uploaded_file = Path(uploaded_file)
 
-        assert uploaded_file.name == testfile10Mb_csv.name
+        assert uploaded_file.name == testfile10MB_csv.name
         assert uploaded_file.exists()
-        assert uploaded_file.stat().st_size == testfile10Mb_csv.stat().st_size
+        assert uploaded_file.stat().st_size == testfile10MB_csv.stat().st_size
 
         # cleanup
         shutil.rmtree(uploaded_file.parent)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -21,7 +21,7 @@ from .utils import create_file
 
 
 @pytest.fixture
-def testfile10Mb_csv():
+def testfile10MB_csv():
     file = Path(__file__).resolve().parent / "mytestfile.csv"
     create_file(file, filesize_mb=10)
     yield file
@@ -42,7 +42,7 @@ def test_render01_render_component(dash_duo):
 
 
 # Run with pytest -k upload01
-def test_upload01_upload_a_file(dash_duo, testfile10Mb_csv):
+def test_upload01_upload_a_file(dash_duo, testfile10MB_csv):
     app = import_app("usage")
     dash_duo.start_server(app)
 
@@ -57,7 +57,7 @@ def test_upload01_upload_a_file(dash_duo, testfile10Mb_csv):
     upload_input = upload.find_element(
         By.XPATH, "//input[@name='dash-uploader-upload']"
     )
-    upload_input.send_keys(str(testfile10Mb_csv))
+    upload_input.send_keys(str(testfile10MB_csv))
     # Wait until file is uploaded
 
     upload_label = upload.find_element(By.XPATH, "//label")
@@ -77,9 +77,9 @@ def test_upload01_upload_a_file(dash_duo, testfile10Mb_csv):
     uploaded_file = callback_output.find_element(By.XPATH, "//ul").text
     uploaded_file = Path(uploaded_file)
 
-    assert uploaded_file.name == testfile10Mb_csv.name
+    assert uploaded_file.name == testfile10MB_csv.name
     assert uploaded_file.exists()
-    assert uploaded_file.stat().st_size == testfile10Mb_csv.stat().st_size
+    assert uploaded_file.stat().st_size == testfile10MB_csv.stat().st_size
 
     # cleanup
     shutil.rmtree(uploaded_file.parent)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,7 +36,7 @@ def create_file(filename, filesize_mb=1):
     filename: str
         The filename
     filesize_mb: numeric
-        The file size in Mb.
+        The file size in MB.
     """
     with open(filename, "wb") as f:
         f.seek(int(1024 * 1024 * filesize_mb))

--- a/usage.py
+++ b/usage.py
@@ -24,7 +24,7 @@ def get_upload_component(id):
         text_completed="Completed: ",
         cancel_button=True,
         pause_button=True,
-        max_file_size=130,  # 130 Mb
+        max_file_size=130,  # 130 MB
         max_total_size=350,
         # filetypes=["csv", "zip"],
         upload_id=uuid.uuid1(),  # Unique session id


### PR DESCRIPTION
This PR finds and replaces usages of "Mb" with "MB".

1 MB (megabyte) = 8 Mb (megabit). Conventionally, MB is a unit used for storage and Mb is used to quantify network speeds.