### PR TITLE
keep packaging version constant on dev and release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
             # Needs: import chromedriver_binary to the top of your test script.
             "chromedriver-binary",
             "Werkzeug~=2.0.3",
-            "packaging>22"
         ]
     },
     classifiers=[


### PR DESCRIPTION
Since packaging==21.0 passed all tests (except for [this PR](https://github.com/fohrloop/dash-uploader/pull/136)) on the current codebase, let's keep the development version consistent with the release environment."