### PR TITLE
fix tests on *NIX (skip a test, use /tmp instead of C:\..)

### DIFF
--- a/tests/apps/disabled.py
+++ b/tests/apps/disabled.py
@@ -1,24 +1,29 @@
 """
 Test app used by test_disabled.
 """
-import uuid
-import json
 
-import dash_uploader as du
+import json
+import sys
+import uuid
+
 import dash
 
+import dash_uploader as du
+
 if du.utils.dash_version_is_at_least("2.0.0"):
-    from dash import html, dcc
+    from dash import dcc, html
 else:
     import dash_html_components as html
     import dash_core_components as dcc
 
-from dash.dependencies import Output, Input
+from dash.dependencies import Input, Output
 from dash.exceptions import PreventUpdate
 
 app = dash.Dash(__name__)
 
-UPLOAD_FOLDER_ROOT = r"C:\tmp\Uploads"
+UPLOAD_FOLDER_ROOT = (
+    r"C:\tmp\Uploads" if sys.platform == "win32" else "/tmp/dash-uploader-uploads"
+)
 du.configure_upload(app, UPLOAD_FOLDER_ROOT)
 
 

--- a/tests/apps/testapp.py
+++ b/tests/apps/testapp.py
@@ -1,7 +1,9 @@
+import sys
 import uuid
 
-import dash_uploader as du
 import dash
+
+import dash_uploader as du
 
 if du.utils.dash_version_is_at_least("2.0.0"):
     from dash import html  # if dash <= 2.0.0, use: import dash_html_components as html
@@ -12,7 +14,9 @@ from dash.dependencies import Output
 
 app = dash.Dash(__name__)
 
-UPLOAD_FOLDER_ROOT = r"C:\tmp\Uploads"
+UPLOAD_FOLDER_ROOT = (
+    r"C:\tmp\Uploads" if sys.platform == "win32" else "/tmp/dash-uploader-uploads"
+)
 du.configure_upload(app, UPLOAD_FOLDER_ROOT)
 
 

--- a/tests/apps/testapp_noretry_remove_file.py
+++ b/tests/apps/testapp_noretry_remove_file.py
@@ -1,7 +1,9 @@
+import sys
 import uuid
 
-import dash_uploader as du
 import dash
+
+import dash_uploader as du
 
 if du.utils.dash_version_is_at_least("2.0.0"):
     from dash import html  # if dash <= 2.0.0, use: import dash_html_components as html
@@ -9,9 +11,12 @@ else:
     import dash_html_components as html
 
 from dash.dependencies import Output
+
 from dash_uploader.httprequesthandler import HttpRequestHandler, remove_file
 
-UPLOAD_FOLDER_ROOT = r"C:\tmp\Uploads"
+UPLOAD_FOLDER_ROOT = (
+    r"C:\tmp\Uploads" if sys.platform == "win32" else "/tmp/dash-uploader-uploads"
+)
 app = dash.Dash(__name__)
 
 # A special version of HttpRequestHandler where

--- a/tests/test_uploading_same_file_twice_with_errors.py
+++ b/tests/test_uploading_same_file_twice_with_errors.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 import shutil
 import threading
@@ -139,6 +140,7 @@ def test_uploadtwice01_upload_a_file_twice_and_reserve_it(
 
 
 # Run with pytest -k uploadtwice02
+@pytest.mark.skipif(sys.platform in ["linux", "darwin"], reason="os.unlik() is not blocking on Linux and MacOS")
 def test_uploadtwice02_upload_a_file_twice_with_error(
     dash_duo, testfile10kb_csv, testfile10kb_2_csv
 ):

--- a/tests/test_uploading_same_file_twice_with_errors.py
+++ b/tests/test_uploading_same_file_twice_with_errors.py
@@ -1,19 +1,20 @@
-import sys
-from pathlib import Path
 import shutil
+import sys
 import threading
 import time
+from pathlib import Path
 
 import chromedriver_binary
-
-from dash.testing.application_runners import import_app
 import pytest
+from dash.testing.application_runners import import_app
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-
+from selenium.webdriver.support.ui import WebDriverWait
 
 from .utils import create_file
+
+# On *nix or not?
+ON_NIX = sys.platform in ["linux", "darwin"]
 
 
 @pytest.fixture
@@ -33,9 +34,21 @@ def testfile10kb_2_csv():
 
 
 def reserve_file_for_while(filepath, wait_time):
-    f = open(filepath, "r")
+
+    if ON_NIX:
+        filepath.chmod(0o000)
+        # import pdb
+
+        # pdb.set_trace()
+    else:
+        f = open(filepath, "r")  # reserves the file on Windows
+
     time.sleep(wait_time)
-    f.close()
+
+    if ON_NIX:
+        ...
+    else:
+        f.close()
 
 
 HOLD_TIME_FOR_FILE = 1.5  # seconds
@@ -140,7 +153,6 @@ def test_uploadtwice01_upload_a_file_twice_and_reserve_it(
 
 
 # Run with pytest -k uploadtwice02
-@pytest.mark.skipif(sys.platform in ["linux", "darwin"], reason="os.unlik() is not blocking on Linux and MacOS")
 def test_uploadtwice02_upload_a_file_twice_with_error(
     dash_duo, testfile10kb_csv, testfile10kb_2_csv
 ):


### PR DESCRIPTION
Replaces: https://github.com/fohrloop/dash-uploader/pull/136

- The tests were failing on linux/macOS, since one of the tests was testing a case where a file could not be used since it was used on another process. That problem was originally only seen on Windows, and so far it seems that it's not possible to reproduce on linux
- Also using `/tmp/dash-uploader-uploads`  instead of `C:\tmp\Uploads` for the test data upload location on *nix.