### PR TITLE
Remove packaging.version.LegacyVersion from dash version check

### DIFF
--- a/dash_uploader/callbacks.py
+++ b/dash_uploader/callbacks.py
@@ -14,8 +14,6 @@ def compare_dash_version(req_version="1.12"):
     This is a private method, and should not be exposed to users.
     """
     cur_version = version.parse(dashversion)
-    if isinstance(cur_version, version.LegacyVersion):
-        return False
     return cur_version >= version.parse(req_version)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash_uploader",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Upload large files using resumable.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the issue in #111
The `packaging` python package deprecated the use of `packaging.version.LegacyVersion`. This pull request just removes this check and bumps the `dash_uploader` version to `0.6.1`.